### PR TITLE
Fix crash due to bad handling of race in lock initiator

### DIFF
--- a/include/async_mutex.hpp
+++ b/include/async_mutex.hpp
@@ -395,7 +395,12 @@ void async_lock_initiator_base<Waiter>::operator()(Handler &&handler) {
                                                        std::memory_order_acquire, std::memory_order_relaxed))
             {
                 // Lock acquired, resume the awaiter stright away
-                Waiter(m_mutex, nullptr, std::forward<Handler>(handler)).completion();
+                if (waiter) {
+                    waiter->next = nullptr;
+                    waiter->completion();
+                } else {
+                    Waiter(m_mutex, nullptr, std::forward<Handler>(handler)).completion();
+                }
                 return;
             }
         } else {


### PR DESCRIPTION
When the initial compare_exchange in async_lock_initiator_base::operator() that would transition from unlocked to locked state fails, i.e. there's another thread that races with the current one and unlocks the lock while the current thread is in the initiator trying to acquire the lock, we fall-through and create a new Waiter object and move the completion handler into it.

In the next loop iteration the compare_exchange is successful now, the current thread acquires the lock and we must use the existing Waiter object, because it owns the completion token. Otherwise we eventually crash trying to obtain an executor for an invalid completion token.